### PR TITLE
Exception handling for download promise. This improves downloads of albums with missing files.

### DIFF
--- a/download_album.js
+++ b/download_album.js
@@ -98,7 +98,11 @@ function getLinksAndTags(html, domain) {
 
 function executeInChunks(callbackArgs, callback, queueSize = 5) {
   const execWith = async (element, index) => {
-    await callback(element);
+    try {
+      await callback(element);
+    } catch (error) {
+        console.warn('Download of: ', element, " FAILED with error: ", error);
+    }
     return index;
   };
 
@@ -115,7 +119,7 @@ function executeInChunks(callbackArgs, callback, queueSize = 5) {
         queueArray.splice(index, 1, execWith(callbackArgs.shift(), index));
         keepQueueSize();
       } catch (error) {
-        console.log('Cannot assemble another chunk');
+        console.error('Cannot assemble another chunk, error: ', error);
         throw error;
       }
     }


### PR DESCRIPTION
- Added exception handling for download promise. This avoids the script to fail on the first file which isn't available. musify.club sometimes removes files from albums. With better error handling those albums can be fetched without crashing with just the file missing. Example of such an album can be found [here](https://musify.club/release/hesperion-xxi-bal-kan-honey-and-blood-miel-et-sang-cd-1-2013-1547200) 
- Improved error messaging for another error handler by actually passing the exception object to the log output.